### PR TITLE
docs: add reciprocal link to AI Tool Review's guides hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Designed with love for beginners 🌱 to experts. 🌳
 Enable with `/guide:game-mode on`
 
 > **Listen to this guide** — [NotebookLM audio overview](https://notebooklm.google.com/notebook/61c00692-3e07-4cac-887a-3360520d8f94) provides an AI-generated audio reflection of the guide content.
+>
+> **Featured on** — [AI Tool Review](https://aitoolreview.ai/guides/) lists this guide among its curated Claude Code resources.
 
 *⭐ Find this useful? Star the repo to follow updates and show support!* <a href="https://github.com/OriNachum/claude-code-guide/stargazers"><img src="https://img.shields.io/github/stars/OriNachum/claude-code-guide?style=social" alt="GitHub stars"></a>
 

--- a/index.md
+++ b/index.md
@@ -53,6 +53,8 @@ The guide is packaged as a Claude Code plugin with seven skills:
 <img width="600" alt="Plugin in action" src="https://github.com/user-attachments/assets/3643154f-00e9-4793-886e-e49adfee54ef" />
 
 > **Listen to this guide** — [NotebookLM audio overview](https://notebooklm.google.com/notebook/61c00692-3e07-4cac-887a-3360520d8f94) provides an AI-generated audio reflection of the guide content.
+>
+> **Featured on** — [AI Tool Review](https://aitoolreview.ai/guides/) lists this guide among its curated Claude Code resources.
 
 *⭐ Find this useful? Star the repo to follow updates and show support!* <a href="https://github.com/OriNachum/claude-code-guide/stargazers"><img src="https://img.shields.io/github/stars/OriNachum/claude-code-guide?style=social" alt="GitHub stars"></a>
 


### PR DESCRIPTION
## What

Adds a small **"Featured on"** callout to the README and the site homepage (`index.md`) linking to [AI Tool Review's guides hub](https://aitoolreview.ai/guides/).

## Why

[AI Tool Review](https://aitoolreview.ai/guides/) — a community-curated catalog of AI dev tools — already features this project in the **"External Resources"** section of its Claude Code guides page (using our repo's own description). This reciprocates the link and points our readers to a quality external set of Claude Code guides (team token budgeting, subagent model routing, loop engineering).

> Note: the correct domain is `aitoolreview.ai` (no "s"). A separate, unrelated `aitoolsreview.co.uk`/`.ai` site exists — we deliberately do **not** link to that one.

## Implementation notes

- The callout is grouped into the same blockquote as the existing NotebookLM "Listen to this guide" note, which avoids introducing an `MD028` (blank-line-inside-blockquote) lint error. Verified: branch and `main` both report the same 25 pre-existing markdownlint findings — **zero new** ones.
- README and `index.md` are human-facing / website content, not plugin content (nothing under `skills/`, `hooks/`, `.claude-plugin/`, or reference docs changed), so per CLAUDE.md this needs **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude